### PR TITLE
Fix github URLs in package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,15 +3,16 @@
   "description": "Get some data about how V8's GC is behaving within your node program .",
   "version": "0.0.1",
   "author": "Lloyd Hilaiel (http://lloyd.io)",
+  "homepage": "https://github.com/lloyd/node-gcstats",
   "engines": { "node": ">= 0.6.0" },
   "repository": {
         "type": "git",
-        "url": "https://github.com/lloydncb000gt/gcstats.git"
+        "url": "https://github.com/lloyd/node-gcstats.git"
    },
   "main": "include.js",
    "licenses": [ { "type": "wtfpl" } ],
    "bugs": {
-     "url" : "https://github.com/lloyd/gcstats/issues"
+     "url" : "https://github.com/lloyd/node-gcstats/issues"
    },
    "scripts": {
      "install": "make build"


### PR DESCRIPTION
All github URLs in the package are wrong, and it takes a bit of twiddling to get to the right location.  This patch fixes that (or breaks it depending on your perspective).
