### PR TITLE
Fix for Issue #11 - support for OSX x64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 TESTS = test/*.js
 
-all: build
+all: test
 
 build: clean configure compile
 
 configure:
-	node-waf configure
+	node-gyp configure
 
-compile:
-	node-waf build
+compile: configure
+	node-gyp build
 
 clean:
-	rm -Rf build
+	node-gyp clean
 
 
 .PHONY: clean test build

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TESTS = test/*.js
 
-all: test
+all: build test
 
 build: clean configure compile
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,15 @@
+{
+  'targets': [
+    {
+      'target_name': 'memwatch',
+      'include_dirs': [
+      ],
+      'sources': [
+        'src/heapdiff.cc',
+        'src/init.cc',
+        'src/memwatch.cc',
+	'src/util.cc'
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
    },
    "devDependencies": {
      "mocha": "1.2.2",
-     "should": "0.6.3"
+     "should": "0.6.3",
+     "node-gyp": "0.5.7"
    },
    "contributors": [
-     "Jed Parsons (@jedp)"
+     "Jed Parsons (@jedp)",
+     "Jeff Haynie (@jhaynie)"
    ]
 }


### PR DESCRIPTION
This is a pull request for https://github.com/lloyd/node-memwatch/issues/11

This seems to work fine for me and my local machine by moving to node-gyp for building for node >=0.8.0
