### PR TITLE
magic has no method 'upon_gc'

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -8,17 +8,17 @@
 #include "heapdiff.hh"
 #include "memwatch.hh"
 
-extern "C" {
-    void init (v8::Handle<v8::Object> target)
-    {
-        v8::HandleScope scope;
-        heapdiff::HeapDiff::Initialize(target);
+using namespace v8;
 
-        NODE_SET_METHOD(target, "upon_gc", memwatch::upon_gc);
-        NODE_SET_METHOD(target, "gc", memwatch::trigger_gc);
+void init (Handle<Object> target)
+{
+    HandleScope scope;
+    heapdiff::HeapDiff::Initialize(target);
 
-        v8::V8::AddGCEpilogueCallback(memwatch::after_gc);
-    }
+    NODE_SET_METHOD(target, "upon_gc", memwatch::upon_gc);
+    NODE_SET_METHOD(target, "gc", memwatch::trigger_gc);
 
-    NODE_MODULE(memwatch, init);
-};
+    V8::AddGCEpilogueCallback(memwatch::after_gc);
+}
+
+NODE_MODULE(memwatch, init);


### PR DESCRIPTION
on both node v0.8.9 and v0.10.20 i get this error message when running (build went ok):

```
./include.js:10
magic.upon_gc(function(has_listeners, event, data) {
      ^
TypeError: Object #<Object> has no method 'upon_gc'
    at Object.<anonymous> (./include.js:10:7)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (./examples/basic_heapdiff.js:2:12)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
```

I just copied the code style from http://nodejs.org/api/addons.html and it worked again.

I'm using debian sid and [nvm](https://github.com/creationix/nvm).
