### PR TITLE
Typo fix: aver => after

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The `info` object will look something like:
 ### Heap Usage
 
 The best way to evaluate your memory footprint is to look at heap
-usage right aver V8 performs garbage collection.  `memwatch` does
+usage right after V8 performs garbage collection.  `memwatch` does
 exactly this - it checks heap usage only after GC to give you a stable
 baseline of your actual memory usage.
 


### PR DESCRIPTION
(Thought I sent this the other day but it looks like I missed it)
