### PR TITLE
Don't close handle scope in GC epilogue callback

### DIFF
--- a/include.js
+++ b/include.js
@@ -1,6 +1,10 @@
-const
-magic = require('./build/Release/memwatch'),
-events = require('events');
+const events = require('events');
+
+try {
+  var magic = require('./build/Release/memwatch');
+} catch (e) {
+  var magic = require('./build/Debug/memwatch');
+}
 
 module.exports = new events.EventEmitter();
 

--- a/src/memwatch.cc
+++ b/src/memwatch.cc
@@ -233,8 +233,6 @@ void memwatch::after_gc(GCType type, GCCallbackFlags flags)
     // windows.  see: https://github.com/joyent/libuv/pull/629  
     uv_queue_work(uv_default_loop(), &(baton->req),
 		  noop_work_func, (uv_after_work_cb)AsyncMemwatchAfter);
-
-    scope.Close(Undefined());
 }
 
 Handle<Value> memwatch::upon_gc(const Arguments& args) {


### PR DESCRIPTION
Don't call v8::HandleScope::Close() from the 'after GC' callback, there
is no parent handle scope to move the value to.  Fixes the following
error in node.js debug builds:

```
FATAL ERROR: v8::HandleScope::CreateHandle() Cannot create a handle
without a HandleScope
```
