### PR TITLE
fix lib exporting if buildtype=debug

### DIFF
--- a/include.js
+++ b/include.js
@@ -1,5 +1,5 @@
 const
-magic = require('./build/Release/memwatch'),
+magic = require('bindings')('memwatch'),
 events = require('events');
 
 module.exports = new events.EventEmitter();

--- a/package.json
+++ b/package.json
@@ -3,15 +3,21 @@
   "description": "Keep an eye on your memory usage, and discover and isolate leaks.",
   "version": "0.2.2",
   "author": "Lloyd Hilaiel (http://lloyd.io)",
-  "engines": { "node": ">= 0.6.0" },
+  "engines": {
+    "node": ">= 0.6.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lloyd/node-memwatch.git"
   },
   "main": "include.js",
-  "licenses": [ { "type": "wtfpl" } ],
+  "licenses": [
+    {
+      "type": "wtfpl"
+    }
+  ],
   "bugs": {
-    "url" : "https://github.com/lloyd/node-memwatch/issues"
+    "url": "https://github.com/lloyd/node-memwatch/issues"
   },
   "scripts": {
     "install": "node-gyp rebuild",
@@ -26,5 +32,8 @@
     "Jed Parsons (@jedp)",
     "Jeff Haynie (@jhaynie)",
     "Justin Matthews (@jmatthewsr-ms)"
-  ]
+  ],
+  "dependencies": {
+    "bindings": "^1.2.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "Justin Matthews (@jmatthewsr-ms)"
   ],
   "dependencies": {
-    "bindings": "^1.2.0"
+    "bindings": "~1.2.0"
   }
 }


### PR DESCRIPTION
Requiring './build/Release/memwatch' fail if node built in debug mode, coz memwatch will build into './build/Debug/memwatch'. It is a node-module 'bindings' to fix this broad spread issue.
